### PR TITLE
Multiple code improvements - squid:S1213, squid:S1854, squid:S1066, squid:S1301, squid:SwitchLastCaseIsDefaultCheck

### DIFF
--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/Artist.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/Artist.java
@@ -56,6 +56,16 @@ import java.util.List;
 
 public class Artist implements Parcelable {
 
+  public static final Creator<Artist> CREATOR = new Creator<Artist>() {
+
+    public Artist createFromParcel(Parcel source) {
+      return new Artist(source);
+    }
+
+    public Artist[] newArray(int size) {
+      return new Artist[size];
+    }
+  };
   @SerializedName("followers") public Followers followers;
   @SerializedName("href") public String href;
   @SerializedName("id") public String id;
@@ -64,19 +74,6 @@ public class Artist implements Parcelable {
   @SerializedName("popularity") public int popularity;
 
   public Artist() {
-  }
-
-  @Override public int describeContents() {
-    return 0;
-  }
-
-  @Override public void writeToParcel(Parcel parcel, int i) {
-    parcel.writeString(this.href);
-    parcel.writeString(this.id);
-    parcel.writeString(this.name);
-    parcel.writeParcelable(this.followers, 0);
-    parcel.writeInt(this.popularity);
-    parcel.writeTypedList(this.artistImages);
   }
 
   protected Artist(Parcel in) {
@@ -92,14 +89,16 @@ public class Artist implements Parcelable {
     in.readTypedList(this.artistImages, ArtistImages.CREATOR);
   }
 
-  public static final Creator<Artist> CREATOR = new Creator<Artist>() {
+  @Override public int describeContents() {
+    return 0;
+  }
 
-    public Artist createFromParcel(Parcel source) {
-      return new Artist(source);
-    }
-
-    public Artist[] newArray(int size) {
-      return new Artist[size];
-    }
-  };
+  @Override public void writeToParcel(Parcel parcel, int i) {
+    parcel.writeString(this.href);
+    parcel.writeString(this.id);
+    parcel.writeString(this.name);
+    parcel.writeParcelable(this.followers, 0);
+    parcel.writeInt(this.popularity);
+    parcel.writeTypedList(this.artistImages);
+  }
 }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/ArtistImages.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/ArtistImages.java
@@ -23,26 +23,6 @@ import com.google.gson.annotations.SerializedName;
 
 public class ArtistImages implements Parcelable {
 
-  @SerializedName("height") public int heigth;
-  @SerializedName("url") public String url;
-  @SerializedName("width") public int width;
-
-  @Override public int describeContents() {
-    return 0;
-  }
-
-  @Override public void writeToParcel(Parcel parcel, int i) {
-    parcel.writeInt(this.heigth);
-    parcel.writeString(this.url);
-    parcel.writeInt(this.width);
-  }
-
-  protected ArtistImages(Parcel in) {
-    this.heigth = in.readInt();
-    this.url = in.readString();
-    this.width = in.readInt();
-  }
-
   public static final Creator<ArtistImages> CREATOR = new Creator<ArtistImages>() {
 
     public ArtistImages createFromParcel(Parcel source) {
@@ -53,4 +33,24 @@ public class ArtistImages implements Parcelable {
       return new ArtistImages[size];
     }
   };
+
+  @SerializedName("height") public int heigth;
+  @SerializedName("url") public String url;
+  @SerializedName("width") public int width;
+
+  protected ArtistImages(Parcel in) {
+    this.heigth = in.readInt();
+    this.url = in.readString();
+    this.width = in.readInt();
+  }
+
+  @Override public int describeContents() {
+    return 0;
+  }
+
+  @Override public void writeToParcel(Parcel parcel, int i) {
+    parcel.writeInt(this.heigth);
+    parcel.writeString(this.url);
+    parcel.writeInt(this.width);
+  }
 }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/Followers.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/Followers.java
@@ -23,23 +23,6 @@ import com.google.gson.annotations.SerializedName;
 
 public class Followers implements Parcelable {
 
-  @SerializedName("href") public String href;
-  @SerializedName("total") public int totalFollowers;
-
-  @Override public int describeContents() {
-    return 0;
-  }
-
-  @Override public void writeToParcel(Parcel parcel, int i) {
-    parcel.writeString(this.href);
-    parcel.writeInt(this.totalFollowers);
-  }
-
-  protected Followers(Parcel in) {
-    this.href = in.readString();
-    this.totalFollowers = in.readInt();
-  }
-
   public static final Creator<Followers> CREATOR = new Creator<Followers>() {
 
     public Followers createFromParcel(Parcel source) {
@@ -50,4 +33,21 @@ public class Followers implements Parcelable {
       return new Followers[size];
     }
   };
+
+  @SerializedName("href") public String href;
+  @SerializedName("total") public int totalFollowers;
+
+  protected Followers(Parcel in) {
+    this.href = in.readString();
+    this.totalFollowers = in.readInt();
+  }
+
+  @Override public void writeToParcel(Parcel parcel, int i) {
+    parcel.writeString(this.href);
+    parcel.writeInt(this.totalFollowers);
+  }
+
+  @Override public int describeContents() {
+    return 0;
+  }
 }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/Track.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/model/Track.java
@@ -23,27 +23,6 @@ import com.google.gson.annotations.SerializedName;
 
 public class Track implements Parcelable {
 
-  @SerializedName("name") public String name;
-  @SerializedName("preview_url") public String preview_url;
-  @SerializedName("track_number") public int track_number;
-  @SerializedName("album") public Album album;
-
-  @Override public int describeContents() {
-    return 0;
-  }
-
-  @Override public void writeToParcel(Parcel parcel, int i) {
-    parcel.writeString(this.name);
-    parcel.writeString(this.preview_url);
-    parcel.writeInt(this.track_number);
-  }
-
-  protected Track(Parcel in) {
-    this.name = in.readString();
-    this.preview_url = in.readString();
-    this.track_number = in.readInt();
-  }
-
   public static final Creator<Track> CREATOR = new Creator<Track>() {
 
     public Track createFromParcel(Parcel source) {
@@ -54,4 +33,25 @@ public class Track implements Parcelable {
       return new Track[size];
     }
   };
+
+  @SerializedName("name") public String name;
+  @SerializedName("preview_url") public String preview_url;
+  @SerializedName("track_number") public int track_number;
+  @SerializedName("album") public Album album;
+
+  protected Track(Parcel in) {
+    this.name = in.readString();
+    this.preview_url = in.readString();
+    this.track_number = in.readInt();
+  }
+
+  @Override public int describeContents() {
+    return 0;
+  }
+
+  @Override public void writeToParcel(Parcel parcel, int i) {
+    parcel.writeString(this.name);
+    parcel.writeString(this.preview_url);
+    parcel.writeInt(this.track_number);
+  }
 }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/service/AudioPlayerService.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/service/AudioPlayerService.java
@@ -64,11 +64,10 @@ public class AudioPlayerService extends Service
 
   @Override public int onStartCommand(Intent intent, int flags, int startId) {
 
-    if (intent != null && intent.hasExtra(EXTRA_TRACK_PREVIEW_URL)) {
-      if (intent.getStringExtra(EXTRA_TRACK_PREVIEW_URL) != null) {
-        setTrackPreviewUrl(intent.getStringExtra(EXTRA_TRACK_PREVIEW_URL));
-        onPlayAudio(0);
-      }
+    if (intent != null && intent.hasExtra(EXTRA_TRACK_PREVIEW_URL)
+        && intent.getStringExtra(EXTRA_TRACK_PREVIEW_URL) != null) {
+      setTrackPreviewUrl(intent.getStringExtra(EXTRA_TRACK_PREVIEW_URL));
+      onPlayAudio(0);
     }
     return START_STICKY;
   }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/activity/TracksActivity.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/activity/TracksActivity.java
@@ -140,10 +140,9 @@ public class TracksActivity extends AppCompatActivity
   }
 
   @Override public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case android.R.id.home:
-        onBackPressed();
-        return true;
+    if (item.getItemId() == android.R.id.home) {
+      onBackPressed();
+      return true;
     }
     return super.onOptionsItemSelected(item);
   }
@@ -153,16 +152,10 @@ public class TracksActivity extends AppCompatActivity
 
     if (verticalOffset == 0) {
       if (state != State.EXPANDED) hideAndShowTitleToolbar(View.GONE);
-
-      state = State.EXPANDED;
     } else if (Math.abs(verticalOffset) >= appBarLayout.getTotalScrollRange()) {
       if (state != State.COLLAPSED) hideAndShowTitleToolbar(View.VISIBLE);
-
-      state = State.COLLAPSED;
     } else {
       if (state != State.IDLE) hideAndShowTitleToolbar(View.GONE);
-
-      state = State.IDLE;
     }
   }
 

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/fragment/ArtistsFragment.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/fragment/ArtistsFragment.java
@@ -51,10 +51,6 @@ import gdg.androidtitlan.spotifymvp.example.view.ArtistsMvpView;
 public class ArtistsFragment extends Fragment
     implements ArtistsMvpView, SearchView.OnQueryTextListener {
 
-  public ArtistsFragment() {
-    setHasOptionsMenu(true);
-  }
-
   @Bind(R.id.toolbar) Toolbar toolbar;
   @Bind(R.id.rv_artists) RecyclerView rv_artist;
   @Bind(R.id.pv_artists) ProgressBar pv_artists;
@@ -64,6 +60,10 @@ public class ArtistsFragment extends Fragment
 
   private SearchView searchView;
   private ArtistsPresenter artistsPresenter;
+
+  public ArtistsFragment() {
+    setHasOptionsMenu(true);
+  }
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/fragment/AudioPlayerFragment.java
@@ -55,21 +55,6 @@ import gdg.androidtitlan.spotifymvp.example.view.PlayerMVPView;
 public class AudioPlayerFragment extends DialogFragment
     implements PlayerMVPView, SeekBar.OnSeekBarChangeListener {
 
-  public static AudioPlayerFragment newInstance(String tracks, int position) {
-    AudioPlayerFragment audioPlayerFragment = new AudioPlayerFragment();
-    Bundle bundle = new Bundle();
-    bundle.putString(TracksActivity.EXTRA_TRACKS, tracks);
-    bundle.putInt(TracksActivity.EXTRA_TRACK_POSITION, position);
-    audioPlayerFragment.setArguments(bundle);
-    return audioPlayerFragment;
-  }
-
-  @NonNull @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
-    Dialog dialog = super.onCreateDialog(savedInstanceState);
-    dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
-    return dialog;
-  }
-
   @Bind(R.id.iv_album_player) ImageView iv_album_player;
   @Bind(R.id.txt_track_title_player) TextView txt_track_title_player;
   @Bind(R.id.txt_album_title_player) TextView txt_album_title_player;
@@ -86,6 +71,21 @@ public class AudioPlayerFragment extends DialogFragment
   private List<Track> trackList;
   private int trackPosition;
   private AudioPlayerPresenter audioPlayerPresenter;
+
+  public static AudioPlayerFragment newInstance(String tracks, int position) {
+    AudioPlayerFragment audioPlayerFragment = new AudioPlayerFragment();
+    Bundle bundle = new Bundle();
+    bundle.putString(TracksActivity.EXTRA_TRACKS, tracks);
+    bundle.putInt(TracksActivity.EXTRA_TRACK_POSITION, position);
+    audioPlayerFragment.setArguments(bundle);
+    return audioPlayerFragment;
+  }
+
+  @NonNull @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
+    Dialog dialog = super.onCreateDialog(savedInstanceState);
+    dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+    return dialog;
+  }
 
   @Nullable @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/widget/ShadowFrameLayout.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/widget/ShadowFrameLayout.java
@@ -14,6 +14,17 @@ import android.widget.FrameLayout;
 import gdg.androidtitlan.spotifymvp.R;
 
 public class ShadowFrameLayout extends FrameLayout {
+  private static Property<ShadowFrameLayout, Float> SHADOW_ALPHA =
+          new Property<ShadowFrameLayout, Float>(Float.class, "shadowAlpha") {
+            @Override public Float get(ShadowFrameLayout dsfl) {
+              return dsfl.mAlpha;
+            }
+
+            @Override public void set(ShadowFrameLayout dsfl, Float value) {
+              dsfl.mAlpha = value;
+              ViewCompat.postInvalidateOnAnimation(dsfl);
+            }
+          };
   private Drawable mShadowDrawable;
   private NinePatchDrawable mShadowNinePatchDrawable;
   private int mShadowTopOffset;
@@ -94,16 +105,4 @@ public class ShadowFrameLayout extends FrameLayout {
     ViewCompat.postInvalidateOnAnimation(this);
     setWillNotDraw(!mShadowVisible || mShadowDrawable == null);
   }
-
-  private static Property<ShadowFrameLayout, Float> SHADOW_ALPHA =
-      new Property<ShadowFrameLayout, Float>(Float.class, "shadowAlpha") {
-        @Override public Float get(ShadowFrameLayout dsfl) {
-          return dsfl.mAlpha;
-        }
-
-        @Override public void set(ShadowFrameLayout dsfl, Float value) {
-          dsfl.mAlpha = value;
-          ViewCompat.postInvalidateOnAnimation(dsfl);
-        }
-      };
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1854 - Dead stores should be removed.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1301 - "switch" statements should have at least 3 "case" clauses.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1301
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava