### PR TITLE
Multiple code improvements - squid:S1118, squid:S00117, squid:S1068, squid:S1659, squid:UselessParenthesesCheck

### DIFF
--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/client/Constants.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/client/Constants.java
@@ -24,4 +24,6 @@ public class Constants {
   public static final String PATH_ARTIST_TRACKS = "artistId";
   public static final String ARTIST_TRACKS =
       "v1/artists/{" + PATH_ARTIST_TRACKS + "}/top-tracks?country=SE";
+
+  private Constants() {}
 }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/client/FactorySpotifyClient.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/client/FactorySpotifyClient.java
@@ -22,6 +22,8 @@ import retrofit.RxJavaCallAdapterFactory;
 
 public class FactorySpotifyClient {
 
+  private FactorySpotifyClient(){}
+
   public static SpotifyService create() {
 
     Retrofit retrofit = new Retrofit.Builder().baseUrl(Constants.SPOTIFY_API)

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/exception/HttpNotFound.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/api/exception/HttpNotFound.java
@@ -23,6 +23,8 @@ public class HttpNotFound {
   public final static String SERVER_INTERNET_ERROR =
       "Unable to resolve host \"multimedia.telesurtv.net\": No address associated with hostname";
 
+  private HttpNotFound() {}
+
   public static boolean isHttp404(Throwable error) {
     return error instanceof HttpException && ((HttpException) error).code() == 404;
   }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/model/ArtistsInteractor.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/model/ArtistsInteractor.java
@@ -40,7 +40,7 @@ public class ArtistsInteractor {
     mSpotifyService.searchArtist(query)
         .subscribeOn(mSpotifyApp.SubscribeScheduler())
         .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(ArtistsSearch -> onSuccess(ArtistsSearch, artistCallback),
+        .subscribe(artistsSearch -> onSuccess(artistsSearch, artistCallback),
             throwable -> onError(throwable, artistCallback));
   }
 

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/model/TracksInteractor.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/model/TracksInteractor.java
@@ -40,7 +40,7 @@ public class TracksInteractor {
     mSpotifyService.searchTrackList(query)
         .subscribeOn(mSpotifyApp.SubscribeScheduler())
         .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(Tracks -> onSuccess(Tracks, trackCallback),
+        .subscribe(tracks -> onSuccess(tracks, trackCallback),
             throwable -> onError(throwable, trackCallback));
   }
 

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/service/AudioPlayerService.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/service/AudioPlayerService.java
@@ -234,7 +234,7 @@ public class AudioPlayerService extends Service
 
   public int getTrackDuration() {
     if (mediaPlayer != null && (isPlayerPaused || mediaPlayer.isPlaying())) {
-      return (mediaPlayer.getDuration() / 1000);
+      return mediaPlayer.getDuration() / 1000;
     } else {
       return 0;
     }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/activity/TracksActivity.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/activity/TracksActivity.java
@@ -210,11 +210,11 @@ public class TracksActivity extends AppCompatActivity
           .into(iv_collapsing_artist);
       Picasso.with(this).load(artist.artistImages.get(0).url).into(civ_artist);
     } else {
-      final String IMAGE_HOLDER =
+      final String imageHolder =
           "http://d2c87l0yth4zbw-2.global.ssl.fastly.net/i/_global/open-graph-default.png";
       civ_artist.setVisibility(View.GONE);
       Picasso.with(this)
-          .load(IMAGE_HOLDER)
+          .load(imageHolder)
           .transform(new BlurEffect(this, 20))
           .into(iv_collapsing_artist);
     }

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/adapter/ArtistsAdapter.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/adapter/ArtistsAdapter.java
@@ -63,9 +63,9 @@ public class ArtistsAdapter extends RecyclerView.Adapter<ArtistsAdapter.ArtistsV
         }
       }
     } else {
-      final String IMAGE_HOLDER =
+      final String imageHolder =
           "http://d2c87l0yth4zbw-2.global.ssl.fastly.net/i/_global/open-graph-default.png";
-      Picasso.with(holder.imageView.getContext()).load(IMAGE_HOLDER).into(holder.imageView);
+      Picasso.with(holder.imageView.getContext()).load(imageHolder).into(holder.imageView);
     }
 
     holder.itemView.setOnClickListener((View view) -> {

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/widget/ShadowFrameLayout.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/ui/widget/ShadowFrameLayout.java
@@ -18,7 +18,8 @@ public class ShadowFrameLayout extends FrameLayout {
   private NinePatchDrawable mShadowNinePatchDrawable;
   private int mShadowTopOffset;
   private boolean mShadowVisible;
-  private int mWidth, mHeight;
+  private int mWidth;
+  private int mHeight;
   private ObjectAnimator mAnimator;
   private float mAlpha = 1f;
 

--- a/app/src/main/java/gdg/androidtitlan/spotifymvp/example/util/Utils.java
+++ b/app/src/main/java/gdg/androidtitlan/spotifymvp/example/util/Utils.java
@@ -21,6 +21,8 @@ import android.content.Context;
 
 public class Utils {
 
+  private Utils() {}
+
   public static boolean isAudioPlayerServiceRunning(Class<?> serviceClass, Context context) {
     boolean serviceState = false;
     ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);

--- a/app/src/test/java/gdg/androidtitlan/spotifymvp/data/FakeSpotifyAPI.java
+++ b/app/src/test/java/gdg/androidtitlan/spotifymvp/data/FakeSpotifyAPI.java
@@ -27,9 +27,9 @@ import gdg.androidtitlan.spotifymvp.example.api.model.ArtistsSearch;
 public class FakeSpotifyAPI {
 
   private static String ARTIST_ID_TEST = "12Chz98pHFMPJEknJQMWvI";
-  private static String ARTIST_IMAGE_TEST =
-      "https://i.scdn.co/image/0b3c04473aa6a2db8235e5092ec3413f35752b8d";
   private static String ARTIST_NAME_TEST = "muse";
+
+  private FakeSpotifyAPI() {}
 
   public static List<Artist> getArtists() {
     List<Artist> artistsList = new ArrayList<>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S1068 - Unused private fields should be removed.
squid:S1659 - Multiple variables should not be declared on the same line.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1659
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava